### PR TITLE
Add twine check and add long_description_content_type in setup.py

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,6 +36,11 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
+      - name: Check wheel
+        run: |
+          python -m pip install twine
+          twine check wheelhouse/*.whl
+
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -59,6 +64,11 @@ jobs:
         run: |
           pip install scikit-build
           python setup.py sdist
+
+      - name: Check sdist
+        run: |
+          pip install twine
+          twine check dist/*.tar.gz
 
       - uses: actions/upload-artifact@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup_kwargs = dict(
     author_email='dev@wildme.org',
     description='Building blocks for recreating darknet networks in pytorch',
     long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     # The following settings retreive the version from git.
     # See https://github.com/pypa/setuptools_scm/ for more information
     setup_requires=['setuptools_scm'],


### PR DESCRIPTION
- Add twine checks to python-publish github workflow

  When trying to upload v3.0.0 to pypi:
  
  ```
  2020-10-20T22:43:04.0290093Z Checking dist/wbia_lightnet-3.0.0-py3-none-any.whl: FAILED
  2020-10-20T22:43:04.0291850Z   `long_description` has syntax errors in markup and would not be rendered on PyPI.
  2020-10-20T22:43:04.0293417Z     line 17: Warning: Inline literal start-string without end-string.
  2020-10-20T22:43:04.0294920Z   warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
  2020-10-20T22:43:04.0556980Z Checking dist/wbia-lightnet-3.0.0.tar.gz: FAILED
  2020-10-20T22:43:04.0559106Z   `long_description` has syntax errors in markup and would not be rendered on PyPI.
  2020-10-20T22:43:04.0561244Z     line 17: Warning: Inline literal start-string without end-string.
  2020-10-20T22:43:04.0563384Z   warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
  2020-10-20T22:43:04.2700117Z Cleaning up orphan processes
  ```
  
  This kind of error can be caught by running `twine check` on the built
  distributions instead of erroring while uploading to pypi.

- Add long_description_content_type in setup.py

  When running twine check:
  
  ```
  2020-10-21T15:07:30.1070752Z Checking wheelhouse/wbia_lightnet-3.0.1.dev1-py3-none-any.whl: FAILED
  2020-10-21T15:07:30.1071735Z   `long_description` has syntax errors in markup and would not be rendered on PyPI.
  2020-10-21T15:07:30.1072681Z     line 17: Warning: Inline literal start-string without end-string.
  2020-10-21T15:07:30.1073551Z   warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
  2020-10-21T15:07:30.1449807Z ##[error]Process completed with exit code 1.
  ```
  
  The long description is from `README.md` so the `long_description_content_type`
  should be `text/markdown`.

